### PR TITLE
Add shortcut for wg-quick with custom location for confs

### DIFF
--- a/kes/modules/kes-core.nix
+++ b/kes/modules/kes-core.nix
@@ -9,6 +9,7 @@
         ../../modules/development/docker.nix
         ../../modules/development/dotnet.nix
         ../../modules/development/webdev.nix
+        ../../modules/development/wireguard.nix
     ];
 
     environment.systemPackages = with pkgs; [

--- a/modules/development/wireguard.nix
+++ b/modules/development/wireguard.nix
@@ -1,0 +1,23 @@
+{ config, pkgs, lib, ... }:
+
+let
+    shortcuts-script = {
+        text = builtins.readFile ../../scripts/shell/wireguard-shortcuts.sh;
+        mode = "0755";
+    };
+in
+{
+    imports = [
+        ../../local/wireguard.local.nix
+    ];
+
+    environment.systemPackages = [ pkgs.wireguard-tools ];
+
+    environment = {
+        etc."profile.d/wireguard-shortcuts.sh" = shortcuts-script;
+
+        shellInit = ''
+            . /etc/profile.d/wireguard-shortcuts.sh
+        '';
+    };
+}

--- a/scripts/shell/wireguard-shortcuts.sh
+++ b/scripts/shell/wireguard-shortcuts.sh
@@ -1,0 +1,33 @@
+#! /bin/sh
+
+wireguard() {
+    case "$1" in
+        up|down)
+            __wg_toggle "$@"
+        ;;
+        list)
+            for file in "$WIREGUARD_CONFS_DIR"/*.conf; do
+                base=${file##*/}
+                echo "${base%.conf}"
+            done
+        ;;
+        *)
+            echo "usage: wireguard <up|down|list> <network>"
+        ;;
+    esac
+}
+
+__wg_toggle() {
+    if [ -z "$2" ]; then
+        echo "usage: wireguard <up|down|list> <network>"
+    fi
+
+    case "$1" in
+        up)
+            sudo wg-quick up "$WIREGUARD_CONFS_DIR/$2.conf"
+        ;;
+        down)
+            sudo wg-quick down "$WIREGUARD_CONFS_DIR/$2.conf"
+        ;;
+    esac
+}

--- a/templates/wireguard.local.nix
+++ b/templates/wireguard.local.nix
@@ -1,0 +1,7 @@
+{ config, pkgs, lib, ... }:
+
+{
+    environment.variables = {
+        WIREGUARD_CONFS_DIR = "$HOME/Nextcloud/Secrets/Wireguard";
+    };
+}


### PR DESCRIPTION
Adds are module for wireguard.
Use `wireguard` to connect to a wireguard network from a config via `wg-quick`.
Directory where configs are stored can be changed via ENV in `wireguard.local.nix`. This defaults to `$HOME/Nextcloud/Secrets/Wireguard`, since I sync my confs via Nextcloud.

`wireguard <up|down> <network>`: Connect/disconnect from a network
`wireguard list`: List of available networks

This addresses the following issue:
Using `wg-quick` is probably the easiest way to connect to a network using a conf file, however the command either expects the confs to be in `/etc/wireguard` or to be given a file path. With the new command, the confs can be in an arbitrary, user-defined location. 

Remember to run `setup.sh` after updating to this commit.