### PR TITLE
[annika] Ignore insecure libsoup-2 package

### DIFF
--- a/annika/software/citrix-ica-client.nix
+++ b/annika/software/citrix-ica-client.nix
@@ -14,25 +14,23 @@
 
     # System packages
     environment.systemPackages = with pkgs; [
-        citrix_workspace # Official ICA client
-        opensc # Smartcard tools and libraries
-        ccid # USB smartcard reader driver
+        # Citrix + smartcard
+        citrix_workspace
+        opensc
+        ccid
 
-        # Audio/video packages for HDX
+        # Multimedia
         pulseaudio
         alsa-utils
         libvdpau
         vdpauinfo
-
-        # GStreamer stack for HDX multimedia optimization
         gst_all_1.gstreamer
         gst_all_1.gst-plugins-base
         gst_all_1.gst-plugins-good
         gst_all_1.gst-plugins-bad
         gst_all_1.gst-plugins-ugly
         gst_all_1.gst-libav
-
-        # MIME helper (for manual .ica association)
         xdg-utils
+        (pkgs.stdenv.cc.cc.lib)
     ];
 }


### PR DESCRIPTION
@XCOAnnika `libsoup_2_4` used by `citrix_workspace` is EOL and considered insecure (see [failed pipeline](https://github.com/AceOfKestrels/nixos-config/actions/runs/16578803203/job/46889644930#step:4:1129)). 

This PR fixes the pipeline by **<ins>ignoring this issue</ins>**. Consider trying to switch to `libsoup_3` using an overlay until the maintainers upgrade the dependency.